### PR TITLE
fix vertical scrolling

### DIFF
--- a/SlimeVolleyballLegacy.html
+++ b/SlimeVolleyballLegacy.html
@@ -2,6 +2,7 @@
 <style type="text/css">
 /* MENU CSS */
 * {margin:0;padding:0;font-family: Arial;}
+body {display: flex}
 h1 {font-size:70;}
 h2 {margin: 8px 0;}
 .SmallButton {


### PR DESCRIPTION
Right now when you switch between levels by pressing space, the page scrolls down slightly and you have to scroll back up. This is caused by the margin on the main element pushing everything down. `display: flex` fixes that.